### PR TITLE
Instead of calling macroAction only on keydown, call it every time

### DIFF
--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -50,9 +50,6 @@ static Key handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState)
     if (mappedKey.flags != (SYNTHETIC | IS_MACRO))
         return mappedKey;
 
-    if (!key_toggled_on(keyState))
-      return Key_NoKey;
-
     Macros_::row = row;
     Macros_::col = col;
     const macro_t *m = macroAction(mappedKey.keyCode, keyState);


### PR DESCRIPTION
Call `macroAction` for all `keyState`s, not only when a key toggled on. This lets the macro itself decide when to act, and makes it possible to have macro effects on the other states.