### PR TITLE
New step types

### DIFF
--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -45,6 +45,28 @@ void Macros_::play(const macro_t *macro_p) {
             handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
             Keyboard.sendReport();
             break;
+
+        case MACRO_ACTION_STEP_KEYCODEDOWN:
+            key.flags = 0;
+            key.keyCode = pgm_read_byte(macro_p++);
+            handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
+            Keyboard.sendReport();
+            break;
+        case MACRO_ACTION_STEP_KEYCODEUP:
+            key.flags = 0;
+            key.keyCode = pgm_read_byte(macro_p++);
+            handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
+            Keyboard.sendReport();
+            break;
+        case MACRO_ACTION_STEP_TAPCODE:
+            key.flags = 0;
+            key.keyCode = pgm_read_byte(macro_p++);
+            handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
+            Keyboard.sendReport();
+            handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
+            Keyboard.sendReport();
+            break;
+
         case END:
         default:
             return;

--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -37,6 +37,14 @@ void Macros_::play(const macro_t *macro_p) {
             handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
             Keyboard.sendReport();
             break;
+        case MACRO_ACTION_STEP_TAP:
+            key.flags = pgm_read_byte(macro_p++);
+            key.keyCode = pgm_read_byte(macro_p++);
+            handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
+            Keyboard.sendReport();
+            handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
+            Keyboard.sendReport();
+            break;
         case END:
         default:
             return;

--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -13,11 +13,11 @@ static void readKeyCodeAndPlay (const macro_t *macro_p, uint8_t flags, uint8_t k
     key.keyCode = pgm_read_byte(macro_p++);
 
     if (keyStates & IS_PRESSED) {
-        handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
+        handle_key_event(key, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
         Keyboard.sendReport();
     }
     if (keyStates & WAS_PRESSED) {
-        handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
+        handle_key_event(key, UNKNOWN_KEYSWITCH_LOCATION, WAS_PRESSED | INJECTED);
         Keyboard.sendReport();
     }
 }

--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -7,7 +7,7 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
 
 byte Macros_::row, Macros_::col;
 
-static void readAndPlay (const macro_t *macro_p, uint8_t flags, uint8_t keyStates) {
+static void readKeyCodeAndPlay (const macro_t *macro_p, uint8_t flags, uint8_t keyStates) {
     Key key;
     key.flags = flags;
     key.keyCode = pgm_read_byte(macro_p++);
@@ -42,25 +42,25 @@ void Macros_::play(const macro_t *macro_p) {
         }
         case MACRO_ACTION_STEP_KEYDOWN:
             flags = pgm_read_byte(macro_p++);
-            readAndPlay (macro_p++, flags, IS_PRESSED);
+            readKeyCodeAndPlay (macro_p++, flags, IS_PRESSED);
             break;
         case MACRO_ACTION_STEP_KEYUP:
             flags = pgm_read_byte(macro_p++);
-            readAndPlay (macro_p++, flags, WAS_PRESSED);
+            readKeyCodeAndPlay (macro_p++, flags, WAS_PRESSED);
             break;
         case MACRO_ACTION_STEP_TAP:
             flags = pgm_read_byte(macro_p++);
-            readAndPlay (macro_p++, flags, IS_PRESSED | WAS_PRESSED);
+            readKeyCodeAndPlay (macro_p++, flags, IS_PRESSED | WAS_PRESSED);
             break;
 
         case MACRO_ACTION_STEP_KEYCODEDOWN:
-            readAndPlay (macro_p++, 0, IS_PRESSED);
+            readKeyCodeAndPlay (macro_p++, 0, IS_PRESSED);
             break;
         case MACRO_ACTION_STEP_KEYCODEUP:
-            readAndPlay (macro_p++, 0, WAS_PRESSED);
+            readKeyCodeAndPlay (macro_p++, 0, WAS_PRESSED);
             break;
         case MACRO_ACTION_STEP_TAPCODE:
-            readAndPlay (macro_p++, 0, IS_PRESSED | WAS_PRESSED);
+            readKeyCodeAndPlay (macro_p++, 0, IS_PRESSED | WAS_PRESSED);
             break;
 
         case END:

--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -7,10 +7,25 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
 
 byte Macros_::row, Macros_::col;
 
+static void readAndPlay (const macro_t *macro_p, uint8_t flags, uint8_t keyStates) {
+    Key key;
+    key.flags = flags;
+    key.keyCode = pgm_read_byte(macro_p++);
+
+    if (keyStates & IS_PRESSED) {
+        handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
+        Keyboard.sendReport();
+    }
+    if (keyStates & WAS_PRESSED) {
+        handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
+        Keyboard.sendReport();
+    }
+}
+
 void Macros_::play(const macro_t *macro_p) {
     macro_t macro = END;
     uint8_t interval = 0;
-    Key key;
+    uint8_t flags;
 
     if (!macro_p)
         return;
@@ -26,45 +41,26 @@ void Macros_::play(const macro_t *macro_p) {
             break;
         }
         case MACRO_ACTION_STEP_KEYDOWN:
-            key.flags = pgm_read_byte(macro_p++);
-            key.keyCode = pgm_read_byte(macro_p++);
-            handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
-            Keyboard.sendReport();
+            flags = pgm_read_byte(macro_p++);
+            readAndPlay (macro_p++, flags, IS_PRESSED);
             break;
         case MACRO_ACTION_STEP_KEYUP:
-            key.flags = pgm_read_byte(macro_p++);
-            key.keyCode = pgm_read_byte(macro_p++);
-            handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
-            Keyboard.sendReport();
+            flags = pgm_read_byte(macro_p++);
+            readAndPlay (macro_p++, flags, WAS_PRESSED);
             break;
         case MACRO_ACTION_STEP_TAP:
-            key.flags = pgm_read_byte(macro_p++);
-            key.keyCode = pgm_read_byte(macro_p++);
-            handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
-            Keyboard.sendReport();
-            handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
-            Keyboard.sendReport();
+            flags = pgm_read_byte(macro_p++);
+            readAndPlay (macro_p++, flags, IS_PRESSED | WAS_PRESSED);
             break;
 
         case MACRO_ACTION_STEP_KEYCODEDOWN:
-            key.flags = 0;
-            key.keyCode = pgm_read_byte(macro_p++);
-            handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
-            Keyboard.sendReport();
+            readAndPlay (macro_p++, 0, IS_PRESSED);
             break;
         case MACRO_ACTION_STEP_KEYCODEUP:
-            key.flags = 0;
-            key.keyCode = pgm_read_byte(macro_p++);
-            handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
-            Keyboard.sendReport();
+            readAndPlay (macro_p++, 0, WAS_PRESSED);
             break;
         case MACRO_ACTION_STEP_TAPCODE:
-            key.flags = 0;
-            key.keyCode = pgm_read_byte(macro_p++);
-            handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
-            Keyboard.sendReport();
-            handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
-            Keyboard.sendReport();
+            readAndPlay (macro_p++, 0, IS_PRESSED | WAS_PRESSED);
             break;
 
         case END:

--- a/src/MacroSteps.h
+++ b/src/MacroSteps.h
@@ -5,9 +5,14 @@ typedef enum {
 
     MACRO_ACTION_STEP_INTERVAL,
     MACRO_ACTION_STEP_WAIT,
+
     MACRO_ACTION_STEP_KEYDOWN,
     MACRO_ACTION_STEP_KEYUP,
-    MACRO_ACTION_STEP_TAP
+    MACRO_ACTION_STEP_TAP,
+
+    MACRO_ACTION_STEP_KEYCODEDOWN,
+    MACRO_ACTION_STEP_KEYCODEUP,
+    MACRO_ACTION_STEP_TAPCODE,
 } MacroActionStepType;
 
 typedef uint8_t macro_t;
@@ -18,10 +23,16 @@ typedef uint8_t macro_t;
 
 #define I(n)  MACRO_ACTION_STEP_INTERVAL, n
 #define W(n)  MACRO_ACTION_STEP_WAIT, n
+
 #define Dr(k) MACRO_ACTION_STEP_KEYDOWN, (k).flags, (k).keyCode
 #define D(k)  Dr(Key_ ## k)
 #define Ur(k) MACRO_ACTION_STEP_KEYUP, (k).flags, (k).keyCode
 #define U(k)  Ur(Key_ ## k)
 #define Tr(k) MACRO_ACTION_STEP_TAP, (k).flags, (k).keyCode
 #define T(k)  Tr(Key_ ## k)
+
+#define Dc(k) MACRO_ACTION_STEP_KEYCODEDOWN, (Key_ ## k).keyCode
+#define Uc(k) MACRO_ACTION_STEP_KEYCODEUP, (Key_ ## k).keyCode
+#define Tc(k) MACRO_ACTION_STEP_TAPCODE, (Key_ ## k).keyCode
+
 #define END   MACRO_ACTION_END

--- a/src/MacroSteps.h
+++ b/src/MacroSteps.h
@@ -7,6 +7,7 @@ typedef enum {
     MACRO_ACTION_STEP_WAIT,
     MACRO_ACTION_STEP_KEYDOWN,
     MACRO_ACTION_STEP_KEYUP,
+    MACRO_ACTION_STEP_TAP
 } MacroActionStepType;
 
 typedef uint8_t macro_t;
@@ -21,6 +22,6 @@ typedef uint8_t macro_t;
 #define D(k)  Dr(Key_ ## k)
 #define Ur(k) MACRO_ACTION_STEP_KEYUP, (k).flags, (k).keyCode
 #define U(k)  Ur(Key_ ## k)
-#define Tr(k) Dr(k), Ur(k)
-#define T(k)  D(k), U(k)
+#define Tr(k) MACRO_ACTION_STEP_TAP, (k).flags, (k).keyCode
+#define T(k)  Tr(Key_ ## k)
 #define END   MACRO_ACTION_END


### PR DESCRIPTION
This adds a few new step types, as noted in #4: tapping and keydown, keyup, tap with only the keycode stored. These make it possible to make macro definitions even more compact (which will be very useful for EEPROM storage down the road!), at the cost of about 80 bytes of code. It's only worth it once one has at least a few macros, but then the savings are considerable. On my own sketch, even with the added code complexity, I was able to save 60 bytes. That's over a hundred bytes of macro storage less... and when we want to use EEPROM, of which we have little, compact storage becomes all the more important.

Fixes #4.