### PR TITLE
Make the .type method return MACRO_NONE

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
                      END);
   case MACRO_HELLO:
     if (key_toggled_on(keyState)) {
-      Macros.type(PSTR("Hello world!"));
+      return Macros.type(PSTR("Hello world!"));
     }
     break;
   case MACRO_SPECIAL:
@@ -66,7 +66,7 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
 
 void setup() {
   Kaleidoscope.use(&Macros);
-  
+
   Kaleidoscope.setup ();
 }
 ```

--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -114,7 +114,7 @@ static const Key ascii_to_key_map[] PROGMEM = {
   LSHIFT(Key_Backtick),
 };
 
-void Macros_::type(const char *string) {
+const macro_t *Macros_::type(const char *string) {
   while (true) {
     uint8_t ascii_code = pgm_read_byte(string++);
     if (!ascii_code)
@@ -167,6 +167,8 @@ void Macros_::type(const char *string) {
     handle_keyswitch_event(key, UNKNOWN_KEYSWITCH_LOCATION, WAS_PRESSED | INJECTED);
     Keyboard.sendReport();
   }
+
+  return MACRO_NONE;
 }
 
 static Key handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {

--- a/src/Kaleidoscope-Macros.h
+++ b/src/Kaleidoscope-Macros.h
@@ -14,7 +14,7 @@ class Macros_ : public KaleidoscopePlugin {
   void begin(void) final;
 
   void play(const macro_t *macro_p);
-  void type(const char *string);
+  const macro_t *type(const char *string);
 
   static byte row, col;
 };


### PR DESCRIPTION
This way it can be used in place of a `return MACRO(...)` construct.