### PR TITLE
Allow type() to take any number of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
                      T(0), T(1) );
   case MACRO_HELLO:
     if (keyToggledOn(keyState)) {
-      Macros.type(PSTR("Hello world!"));
+      return Macros.type(PSTR("Hello world!"));
     }
     break;
   case MACRO_SPECIAL:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
                      T(0), T(1) );
   case MACRO_HELLO:
     if (keyToggledOn(keyState)) {
-      return Macros.type(PSTR("Hello world!"));
+      return Macros.type(PSTR("Hello "), PSTR("world!"));
     }
     break;
   case MACRO_SPECIAL:
@@ -92,18 +92,19 @@ The plugin provides a `Macros` object, with the following methods and properties
 >
 > The `macro` argument must be a sequence created with the `MACRO()` helper!
 
-### `.type(string)`
+### `.type(strings...)`
 
-> In cases where we only want to type a string, it is far more convenient to use
-> this method: we do not have to use the `MACRO()` helper, but just give this
-> one a string, and it will type it for us on the keyboard.
+> In cases where we only want to type some strings, it is far more convenient to
+> use this method: we do not have to use the `MACRO()` helper, but just give
+> this one a set of strings, and it will type them for us on the keyboard. We
+> can use as many strings as we want, and all of them will be typed in order.
 >
-> The string is limited to a sequence of printable ASCII characters. No
+> Each string is limited to a sequence of printable ASCII characters. No
 > international symbols, or unicode, or anything like it: just plain ASCII.
 >
-> The `string` argument must also reside in program memory, and the easiest way
-> to do that is to wrap the string in a `PSTR()` helper. See the program code at
-> the beginning of this documentation for an example!
+> Each of `strings` arguments must also reside in program memory, and the
+> easiest way to do that is to wrap the string in a `PSTR()` helper. See the
+> program code at the beginning of this documentation for an example!
 
 ### `.row`, `.col`
 

--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -161,7 +161,7 @@ Key Macros_::lookupAsciiCode(uint8_t ascii_code) {
   return key;
 }
 
-void Macros_::type(const char *string) {
+const macro_t *Macros_::type(const char *string) {
   while (true) {
     uint8_t ascii_code = pgm_read_byte(string++);
     if (!ascii_code)
@@ -177,6 +177,8 @@ void Macros_::type(const char *string) {
     playMacroKeyswitchEvent(key, WAS_PRESSED);
 
   }
+
+  return MACRO_NONE;
 }
 
 static Key handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {

--- a/src/Kaleidoscope-Macros.h
+++ b/src/Kaleidoscope-Macros.h
@@ -14,7 +14,21 @@ class Macros_ : public KaleidoscopePlugin {
   void begin(void) final;
 
   void play(const macro_t *macro_p);
+
+  /* What follows below, is a bit of template magic that allows us to use
+     Macros.type() with any number of arguments, without having to use a
+     sentinel. See the comments on Kaleidoscope.use() for more details - this is
+     the same trick.
+   */
+  inline const macro_t *type() {
+    return MACRO_NONE;
+  }
   const macro_t *type(const char *string);
+  template <typename... Strings>
+  const macro_t *type(const char *first, Strings&&... strings) {
+    type(first);
+    return type(strings...);
+  }
 
   static byte row, col;
 

--- a/src/Kaleidoscope-Macros.h
+++ b/src/Kaleidoscope-Macros.h
@@ -14,7 +14,7 @@ class Macros_ : public KaleidoscopePlugin {
   void begin(void) final;
 
   void play(const macro_t *macro_p);
-  void type(const char *string);
+  const macro_t *type(const char *string);
 
   static byte row, col;
 


### PR DESCRIPTION
To make it easier to type a set of strings, apply some template magic to the `Macros.type()` method. The same trick that is used in `Kaleidoscope.use()`.

Depends on, and includes #7. It can be done without that too, but it was easier this way.
