### PR TITLE
Remove requirement to end MACRO() sequences with special token END

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
                      D(LeftShift), T(M), U(LeftShift), T(O), T(D), T(E), T(L),
                      T(Spacebar),
                      W(100),
-                     T(0), T(1),
-                     END);
+                     T(0), T(1) );
   case MACRO_HELLO:
     if (key_toggled_on(keyState)) {
       Macros.type(PSTR("Hello world!"));
@@ -128,8 +127,10 @@ need to define them in a special way, using the `MACRO` helper (or its
 > Defines a macro, that is built up from `steps` (explained below). The plugin
 > will iterate through the sequence, and re-play the steps in order.
 >
-> The sequence must end with the `END` step, otherwise the playback will not be
-> able to stop, and will have unpredictable behaviour.
+> Note: In older versions of the Macros plugin, the sequence of steps had to end
+> with a special step called END.  This is no longer required.  Existing macros
+> that end with END will still work correctly, but new code should not use END;
+> usage of END is deprecated.
 
 ### `MACRODOWN(steps...)`
 
@@ -147,7 +148,7 @@ need to define them in a special way, using the `MACRO` helper (or its
 
 ## `MACRO` steps
 
-Macro steps can be divided into three groups:
+Macro steps can be divided into two groups:
 
 ### Delays
 
@@ -162,19 +163,13 @@ Macro steps can be divided into three groups:
 Key event steps have two variants: one that prefixes its argument with `Key_`,
 and one that does not. The latter are the `Dr`, `Ur`, and `Tr` variants. In most
 cases, one is likely to use normal keys for the steps, so the `D`, `U`, and `T`
-steps apply the `Key_` prefix. This allows us to write `MACRO(T(X), END)`
-instead of `MACRO(Tr(Key_X), END)` - making the macro definition shorter, and
+steps apply the `Key_` prefix. This allows us to write `MACRO(T(X))`
+instead of `MACRO(Tr(Key_X))` - making the macro definition shorter, and
 more readable.
 
 * `D(key)`, `Dr(key)`: Simulates a key being pressed (pushed down).
 * `U(key)`, `Ur(key)`: Simulates a key being released (going up).
 * `T(key)`, `Tr(key)`: Simulates a key being tapped (pressed first, then released).
-
-### The End
-
-* `END`: Signals the end of the macro. Anything past this step will be ignored.
-  But without this step, the plugin will continue trying to play the macro
-  further, and have unpredictable results.
 
 ## Overrideable methods
 

--- a/src/Kaleidoscope-Macros.cpp
+++ b/src/Kaleidoscope-Macros.cpp
@@ -23,7 +23,7 @@ static void readKeyCodeAndPlay(const macro_t *macro_p, uint8_t flags, uint8_t ke
 }
 
 void Macros_::play(const macro_t *macro_p) {
-  macro_t macro = END;
+  macro_t macro = MACRO_ACTION_END;
   uint8_t interval = 0;
   uint8_t flags;
 
@@ -63,7 +63,7 @@ void Macros_::play(const macro_t *macro_p) {
       readKeyCodeAndPlay(macro_p++, 0, IS_PRESSED | WAS_PRESSED);
       break;
 
-    case END:
+    case MACRO_ACTION_END:
     default:
       return;
     }

--- a/src/MacroSteps.h
+++ b/src/MacroSteps.h
@@ -18,7 +18,7 @@ typedef enum {
 typedef uint8_t macro_t;
 
 #define MACRO_NONE 0
-#define MACRO(...) ({static const macro_t __m[] PROGMEM = { __VA_ARGS__ }; &__m[0]; })
+#define MACRO(...) ({static const macro_t __m[] PROGMEM = { __VA_ARGS__, MACRO_ACTION_END }; &__m[0]; })
 #define MACRODOWN(...) (key_toggled_on(keyState) ? MACRO(__VA_ARGS__) : MACRO_NONE)
 
 #define I(n)  MACRO_ACTION_STEP_INTERVAL, n


### PR DESCRIPTION
Requiring end-users to terminate macros with END strikes me as easy to mess up, and perhaps inelegant.  This PR removes the requirement (under the hood, it adds END automatically).

We maintain backwards-compatibility with existing users who do use END, although users who continue to use END may see a tiny amount of increased code size (1 byte per declared macro, I believe).  Functionality remains intact.

Usage of END is deprecated, and the README for the Macros plugin is updated to this effect.  Eventually, the definition of END may be removed entirely.

Current users of END in my default install are limited to Kaleidoscope/examples and the Kaleidoscope-Numlock plugin.