### PR TITLE
Add deprecation message for END

### DIFF
--- a/src/MacroSteps.h
+++ b/src/MacroSteps.h
@@ -35,4 +35,4 @@ typedef uint8_t macro_t;
 #define Uc(k) MACRO_ACTION_STEP_KEYCODEUP, (Key_ ## k).keyCode
 #define Tc(k) MACRO_ACTION_STEP_TAPCODE, (Key_ ## k).keyCode
 
-#define END   MACRO_ACTION_END
+__attribute__((deprecated("END is no longer required to end macros"))) const MacroActionStepType END = MACRO_ACTION_END;


### PR DESCRIPTION
I figured, since we're doing deprecation messages for other things in Kaleidoscope.

Note, END has officially been deprecated since commit ebd9f35 on Jul 22.