### PR TITLE
Fixed scan order bug

### DIFF
--- a/src/Kaleidoscope-Macros.h
+++ b/src/Kaleidoscope-Macros.h
@@ -7,11 +7,36 @@
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState);
 
+#if !defined(MAX_CONCURRENT_MACROS)
+#define MAX_CONCURRENT_MACROS 8
+#endif
+
+struct MacroKeyEvent {
+  byte key_code;
+  byte key_id;
+  byte key_state;
+};
+
 class Macros_ : public KaleidoscopePlugin {
  public:
   Macros_(void);
 
   void begin(void) final;
+
+  static MacroKeyEvent active_macros[MAX_CONCURRENT_MACROS];
+  static byte active_macro_count;
+  static void addActiveMacroKey(byte key_code, byte key_id, byte key_state) {
+    // If we've got too many active macros, give up:
+    if (active_macro_count >= MAX_CONCURRENT_MACROS) {
+      return;
+    }
+    active_macros[active_macro_count].key_code = key_code;
+    active_macros[active_macro_count].key_id = key_id;
+    active_macros[active_macro_count].key_state = key_state;
+    ++active_macro_count;
+  }
+  static Key handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState);
+  static void loopHook(bool post_clear);
 
   void play(const macro_t *macro_p);
 


### PR DESCRIPTION
Store any macro key events and play them after the event handler pass has finished, so we don't have a problem when holding other keys that are handled after the macro key in a pass. This fixes the problem where held modifiers wouldn't be applied to macros, and also fast repeating of printing characters.

This change does introduce a limit (default: 8) on the number of concurrent macros that can be played.

See the [discussion on the Keyboardio forum](https://community.keyboard.io/t/combining-macros-with-modifiers/980). Fixes #19.